### PR TITLE
chore: use `match` directive instead of deprecated `include`

### DIFF
--- a/github-tag-relevant-user.user.js
+++ b/github-tag-relevant-user.user.js
@@ -2,9 +2,9 @@
 // @name Github Tag Relevant User
 // @version 0.1
 // @description Tag the most relevant user in the context when writing a comment on Github
-// @include https://github.com/*/*/pull/*
-// @include https://github.com/*/*/commit/*
-// @include https://github.com/*/*/issues/*
+// @match https://github.com/*/*/pull/*
+// @match https://github.com/*/*/commit/*
+// @match https://github.com/*/*/issues/*
 // @downloadURL https://raw.githubusercontent.com/colingrodecoeur360/userscripts/master/github-tag-relevant-user.user.js
 // @updateURL https://raw.githubusercontent.com/colingrodecoeur360/userscripts/master/github-tag-relevant-user.user.js
 // ==/UserScript==


### PR DESCRIPTION
## Context

![Screenshot_20220516_121023](https://user-images.githubusercontent.com/9981770/168559834-78736e1f-6648-450a-9866-e919be8f45f8.png)